### PR TITLE
Restrict map to speech-focused repositories

### DIFF
--- a/src/lib/createFuzzySearcher.js
+++ b/src/lib/createFuzzySearcher.js
@@ -2,6 +2,7 @@ import fuzzysort from 'fuzzysort';
 import log from './log.js';
 import config from './config.js';
 import dedupingFetch from './dedupingFetch.js';
+import speechKeywords from './speechKeywords.js';
 
 const fetchedIndex = new Set();
 const seenWords = new Set();
@@ -26,9 +27,11 @@ export default function createFuzzySearcher() {
     if (!fetchedIndex.has(cacheKey)) {
       const p = dedupingFetch(`${config.namesEndpoint}/${cacheKey}.json`).then(data => {
         data.forEach(word => {
-          if (!seenWords.has(word[0])) {
-            words.push({name: word[0], lat: word[1], lon: word[2]});
-            seenWords.add(word[0]);
+          const name = word[0];
+          const lower = name.toLowerCase();
+          if (!seenWords.has(name) && speechKeywords.some(k => lower.includes(k))) {
+            words.push({name, lat: word[1], lon: word[2]});
+            seenWords.add(name);
           }
         });
         fetchedIndex.add(cacheKey);

--- a/src/lib/createMap.js
+++ b/src/lib/createMap.js
@@ -7,6 +7,7 @@ import downloadGroupGraph from "./downloadGroupGraph.js";
 import getComplimentaryColor from "./getComplimentaryColor";
 import createLabelEditor from "./label-editor/createLabelEditor";
 import getColorTheme from "./getColorTheme";
+import speechKeywords from "./speechKeywords.js";
 // import { createRadialGradient } from './gl/createRadialGradient';
 
 const primaryHighlightColor = "#bf2072";
@@ -19,6 +20,10 @@ currentColorTheme.color.forEach((row) => {
   colorStyle.push(["==", ["get", "fill"], row.input], row.output);
 })
 colorStyle.push("#FF0000");
+
+// Build a filter expression that keeps only repositories with speech-related keywords
+const keywordFilters = speechKeywords.map(k => ['>=', ['index-of', k.toLowerCase(), ['downcase', ['get', 'label']]], 0]);
+const speechFilter = ['any', ...keywordFilters];
 
 export default function createMap() {
   const map = new maplibregl.Map(getDefaultStyle());
@@ -361,7 +366,7 @@ function getDefaultStyle() {
           "type": "circle",
           "source": "points-source",
           "source-layer": "points",
-          "filter": ["==", "$type", "Point"],
+          "filter": ["all", ["==", "$type", "Point"], speechFilter],
           "paint": {
             "circle-color": currentColorTheme.circleColor,
             "circle-opacity": [
@@ -394,7 +399,7 @@ function getDefaultStyle() {
           "type": "symbol",
           "source": "points-source",
           "source-layer": "points",
-          "filter": [">=", ["zoom"], 8],
+          "filter": ["all", [">=", ["zoom"], 8], speechFilter],
           "layout": {
             "text-font": [ "Roboto Condensed Regular" ],
             "text-field": ["slice", ["get", "label"], ["+", ["index-of", "/", ["get", "label"]], 1]],

--- a/src/lib/speechKeywords.js
+++ b/src/lib/speechKeywords.js
@@ -1,0 +1,27 @@
+export default [
+  // Tasks / problems
+  'automatic speech recognition', 'asr', 'speech-to-text', 'stt',
+  'text-to-speech', 'tts', 'speech synthesis', 'voice cloning', 'neural tts',
+  'keyword spotting', 'wake word', 'hotword', 'kws',
+  'speaker diarization', 'speaker recognition', 'speaker verification', 'sv', 'sre',
+  'voice activity detection', 'vad',
+  'speech enhancement', 'denoising', 'noise suppression', 'echo cancellation', 'aec', 'beamforming',
+  'prosody', 'phoneme', 'grapheme-to-phoneme', 'g2p',
+  'multilingual asr', 'code-switching', 'low-resource speech',
+
+  // Architectures / libs
+  'whisper', 'wav2vec2', 'hubert', 'conformer', 'rnn-t', 'ctc', 'seq2seq', 'transformer-transducer',
+  'tacotron', 'fastspeech', 'vits', 'wavenet', 'hifi-gan', 'waveglow', 'audiolm', 'neural codec', 'encodec', 'vall-e', 'bark',
+  'torchaudio', 'tensorflow audio', 'jax audio',
+  'kaldi', 'espnet', 'speechbrain', 'nvidia nemo', 'riva', 'deepspeech', 'vosk', 'fairseq s2t', 'julius',
+  'wer', 'cer', 'mos', 'pesq', 'stoi', 'si-sdr',
+
+  // Datasets
+  'librispeech', 'common voice', 'voxceleb', 'ted-lium', 'switchboard', 'fisher', 'aishell', 'gigaspeech', 'ljspeech', 'vctk', 'hificantonese',
+
+  // Roles / org keywords
+  'speech scientist', 'asr engineer', 'tts engineer', 'audio ml engineer',
+  'applied scientist (speech)', 'research scientist (speech)', 'dsp engineer',
+  'conversational ai pm', 'voice assistant pm', 'nlp scientist (speech)',
+  'voice', 'speech', 'audio', 'assistant', 'asr', 'tts', 'conversational', 'spoken language', 'dialog', 'alexa', 'siri', 'cortana'
+];


### PR DESCRIPTION
## Summary
- add comprehensive speech-related keyword list
- filter map layers to show only repos matching speech keywords
- limit fuzzy search to speech repositories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npx eslint . --ext .vue,.js,.jsx,.cjs,.mjs` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_b_68adfc8a5b1c8327be3f70e1420da7f4